### PR TITLE
Use actual URL constant

### DIFF
--- a/Android/SampleSauceTest.java
+++ b/Android/SampleSauceTest.java
@@ -20,7 +20,7 @@ public class SampleSauceCheckBoxTest {
     capabilities.setCapability("deviceOrientation", "portrait");
     capabilities.setCapability("appiumVersion", "1.5.3");
 
-    WebDriver driver = new AndroidDriver<>(new URL("http://ondemand.saucelabs.com:80/wd/hub"), capabilities);
+    WebDriver driver = new AndroidDriver<>(new URL(URL), capabilities);
 
     /**
      * Test Actions here...


### PR DESCRIPTION
Instead of using general string, use actual URL constant defined in class
